### PR TITLE
Add Global Craftbooks, Playtime Requirement, and Weapon Limit RPC

### DIFF
--- a/configs/ammo.lua
+++ b/configs/ammo.lua
@@ -25,6 +25,7 @@ CraftingLocations = CraftingLocations or {}
 local ammunitions = {
     {
         locationId = "ammunitions",
+        craftbookCategory = "ammo_craftbook",
         coords = {
             vector3(410.35, -1283.62, 41.66)
         },
@@ -67,7 +68,8 @@ local ammunitions = {
                             { itemName = "lockpickmold", itemLabel = "Lockpick Mold", itemCount = 1, removeItem = false },
                             { itemName = "ironbar", itemLabel = "Iron Ingot", itemCount = 1, removeItem = true },
                         },
-                        playAnimation = false
+                        playAnimation = false,
+                        requiredPlaytimeMinutes = 0
                     },
                     {
                         itemName = "ammoshotgunnormal",
@@ -83,7 +85,8 @@ local ammunitions = {
                             { itemName = "bulletsmould", itemLabel = "Bullet Mold", itemCount = 1, removeItem = false },
                             { itemName = "powdergun", itemLabel = "Gunpowder", itemCount = 1, removeItem = true },
                         },
-                        playAnimation = false
+                        playAnimation = false,
+                        requiredPlaytimeMinutes = 0
                     },
                     {
                         itemName = "ammoshotgunslug",
@@ -99,7 +102,8 @@ local ammunitions = {
                             { itemName = "bulletsmould", itemLabel = "Bullet Mold", itemCount = 1, removeItem = false },
                             { itemName = "powdergun", itemLabel = "Gunpowder", itemCount = 2, removeItem = true },
                         },
-                        playAnimation = false
+                        playAnimation = false,
+                        requiredPlaytimeMinutes = 0
                     },
                     {
                         itemName = "ammorevolvernormal",
@@ -115,7 +119,8 @@ local ammunitions = {
                             { itemName = "bulletsmould", itemLabel = "Bullet Mold", itemCount = 1, removeItem = false },
                             { itemName = "powdergun", itemLabel = "Gunpowder", itemCount = 1, removeItem = true },
                         },
-                        playAnimation = false
+                        playAnimation = false,
+                        requiredPlaytimeMinutes = 0
                     },
                     {
                         itemName = "ammorevolverexpress",
@@ -131,7 +136,8 @@ local ammunitions = {
                             { itemName = "bulletsmould", itemLabel = "Bullet Mold", itemCount = 1, removeItem = false },
                             { itemName = "powdergun", itemLabel = "Gunpowder", itemCount = 2, removeItem = true },
                         },
-                        playAnimation = false
+                        playAnimation = false,
+                        requiredPlaytimeMinutes = 0
                     },
                     {
                         itemName = "ammorevolvervelocity",
@@ -147,7 +153,8 @@ local ammunitions = {
                             { itemName = "bulletsmould", itemLabel = "Bullet Mold", itemCount = 1, removeItem = false },
                             { itemName = "powdergun", itemLabel = "Gunpowder", itemCount = 3, removeItem = true },
                         },
-                        playAnimation = false
+                        playAnimation = false,
+                        requiredPlaytimeMinutes = 0
                     },
                     {
                         itemName = "ammopistolnormal",
@@ -163,7 +170,8 @@ local ammunitions = {
                             { itemName = "bulletsmould", itemLabel = "Bullet Mold", itemCount = 1, removeItem = false },
                             { itemName = "powdergun", itemLabel = "Gunpowder", itemCount = 1, removeItem = true },
                         },
-                        playAnimation = false
+                        playAnimation = false,
+                        requiredPlaytimeMinutes = 0
                     },
                     {
                         itemName = "ammopistolexpress",
@@ -179,7 +187,8 @@ local ammunitions = {
                             { itemName = "bulletsmould", itemLabel = "Bullet Mold", itemCount = 1, removeItem = false },
                             { itemName = "powdergun", itemLabel = "Gunpowder", itemCount = 2, removeItem = true },
                         },
-                        playAnimation = false
+                        playAnimation = false,
+                        requiredPlaytimeMinutes = 0
                     },
                     {
                         itemName = "ammorepeaternormal",
@@ -195,7 +204,8 @@ local ammunitions = {
                             { itemName = "bulletsmould", itemLabel = "Bullet Mold", itemCount = 1, removeItem = false },
                             { itemName = "powdergun", itemLabel = "Gunpowder", itemCount = 1, removeItem = true },
                         },
-                        playAnimation = false
+                        playAnimation = false,
+                        requiredPlaytimeMinutes = 0
                     },
                     {
                         itemName = "ammorepeatervelocity",
@@ -211,7 +221,8 @@ local ammunitions = {
                             { itemName = "bulletsmould", itemLabel = "Bullet Mold", itemCount = 1, removeItem = false },
                             { itemName = "powdergun", itemLabel = "Gunpowder", itemCount = 3, removeItem = true },
                         },
-                        playAnimation = false
+                        playAnimation = false,
+                        requiredPlaytimeMinutes = 0
                     },
                     {
                         itemName = "ammorepeaterexpress",
@@ -227,7 +238,8 @@ local ammunitions = {
                             { itemName = "bulletsmould", itemLabel = "Bullet Mold", itemCount = 1, removeItem = false },
                             { itemName = "powdergun", itemLabel = "Gunpowder", itemCount = 2, removeItem = true },
                         },
-                        playAnimation = false
+                        playAnimation = false,
+                        requiredPlaytimeMinutes = 0
                     },
                     {
                         itemName = "ammoriflenormal",
@@ -243,7 +255,8 @@ local ammunitions = {
                             { itemName = "bulletsmould", itemLabel = "Bullet Mold", itemCount = 1, removeItem = false },
                             { itemName = "powdergun", itemLabel = "Gunpowder", itemCount = 1, removeItem = true },
                         },
-                        playAnimation = false
+                        playAnimation = false,
+                        requiredPlaytimeMinutes = 0
                     },
                     {
                         itemName = "ammorifleexpress",
@@ -259,7 +272,8 @@ local ammunitions = {
                             { itemName = "bulletsmould", itemLabel = "Bullet Mold", itemCount = 1, removeItem = false },
                             { itemName = "powdergun", itemLabel = "Gunpowder", itemCount = 2, removeItem = true },
                         },
-                        playAnimation = false
+                        playAnimation = false,
+                        requiredPlaytimeMinutes = 0
                     },
                     {
                         itemName = "ammoriflevelocity",
@@ -275,7 +289,8 @@ local ammunitions = {
                             { itemName = "bulletsmould", itemLabel = "Bullet Mold", itemCount = 1, removeItem = false },
                             { itemName = "powdergun", itemLabel = "Gunpowder", itemCount = 3, removeItem = true },
                         },
-                        playAnimation = false
+                        playAnimation = false,
+                        requiredPlaytimeMinutes = 0
                     },
                     {
                         itemName = "ammoelephant",
@@ -291,7 +306,8 @@ local ammunitions = {
                             { itemName = "bulletsmould", itemLabel = "Bullet Mold", itemCount = 1, removeItem = false },
                             { itemName = "powdergun", itemLabel = "Gunpowder", itemCount = 1, removeItem = true },
                         },
-                        playAnimation = false
+                        playAnimation = false,
+                        requiredPlaytimeMinutes = 0
                     },
                     {
                         itemName = "ammovarmint",
@@ -307,7 +323,8 @@ local ammunitions = {
                             { itemName = "bulletsmould", itemLabel = "Bullet Mold", itemCount = 1, removeItem = false },
                             { itemName = "powdergun", itemLabel = "Gunpowder", itemCount = 1, removeItem = true },
                         },
-                        playAnimation = false
+                        playAnimation = false,
+                        requiredPlaytimeMinutes = 0
                     }
                 }
             }

--- a/configs/food.lua
+++ b/configs/food.lua
@@ -3,6 +3,7 @@ CraftingLocations = CraftingLocations or {}
 local food = {
     {
         locationId = "food",
+		craftbookCategory = "food_craftbook",
         coords = {
             vector3(-2396.4, -2387.94, 61.46),
             vector3(2543.07, 800.81, 76.37),
@@ -52,7 +53,8 @@ local food = {
                             { itemName = "meat", itemLabel = "Meat", itemCount = 1, removeItem = true },
                             { itemName = "egg", itemLabel = "Egg", itemCount = 1, removeItem = true },
                         },
-                        playAnimation = false
+                        playAnimation = false,
+                        requiredPlaytimeMinutes = 0
                     },
                     {
                         itemName = "steak",
@@ -64,7 +66,8 @@ local food = {
                         requiredItems = {
                             { itemName = "meat", itemLabel = "Meat", itemCount = 1, removeItem = true },
                         },
-                        playAnimation = false
+                        playAnimation = false,
+                        requiredPlaytimeMinutes = 0
                     },
                     {
                         itemName = "cooked_biggame",
@@ -78,6 +81,7 @@ local food = {
                             { itemName = "salt", itemLabel = "Salt", itemCount = 1, removeItem = true },
                         },
                         playAnimation = false,
+                        requiredPlaytimeMinutes = 0
                     },
                     {
                         itemName = "cooked_game",
@@ -90,7 +94,8 @@ local food = {
                             { itemName = "game", itemLabel = "Game Meat", itemCount = 1, removeItem = true },
                             { itemName = "salt", itemLabel = "Salt", itemCount = 1, removeItem = true },
                         },
-                        playAnimation = false
+                        playAnimation = false,
+                        requiredPlaytimeMinutes = 0
                     },
                     {
                         itemName = "cooked_venison",
@@ -103,7 +108,8 @@ local food = {
                             { itemName = "venison", itemLabel = "Venison", itemCount = 1, removeItem = true },
                             { itemName = "salt", itemLabel = "Salt", itemCount = 1, removeItem = true },
                         },
-                        playAnimation = false
+                        playAnimation = false,
+                        requiredPlaytimeMinutes = 0
                     },
                     {
                         itemName = "cooked_mutton",
@@ -116,7 +122,8 @@ local food = {
                             { itemName = "Mutton", itemLabel = "Mutton", itemCount = 1, removeItem = true },
                             { itemName = "salt", itemLabel = "Salt", itemCount = 1, removeItem = true },
                         },
-                        playAnimation = false
+                        playAnimation = false,
+                        requiredPlaytimeMinutes = 0
                     },
                     {
                         itemName = "cooked_pork",
@@ -129,7 +136,8 @@ local food = {
                             { itemName = "pork", itemLabel = "Pork", itemCount = 1, removeItem = true },
                             { itemName = "salt", itemLabel = "Salt", itemCount = 1, removeItem = true },
                         },
-                        playAnimation = false
+                        playAnimation = false,
+                        requiredPlaytimeMinutes = 0
                     },
                     {
                         itemName = "cooked_bird",
@@ -142,7 +150,8 @@ local food = {
                             { itemName = "bird", itemLabel = "Bird Meat", itemCount = 1, removeItem = true },
                             { itemName = "salt", itemLabel = "Salt", itemCount = 1, removeItem = true },
                         },
-                        playAnimation = false
+                        playAnimation = false,
+                        requiredPlaytimeMinutes = 0
                     },
                     {
                         itemName = "consumable_bluegil",
@@ -155,7 +164,8 @@ local food = {
                             { itemName = "fish", itemLabel = "Fish", itemCount = 1, removeItem = true },
                             { itemName = "salt", itemLabel = "Salt", itemCount = 1, removeItem = true },
                         },
-                        playAnimation = false
+                        playAnimation = false,
+                        requiredPlaytimeMinutes = 0
                     }
                 }
             }

--- a/configs/main.lua
+++ b/configs/main.lua
@@ -42,5 +42,11 @@ Config = {
     craftImageURL = "",            -- Add your desired image URL here
 
     allowGlobalCollection = false, -- true = can collect crafted items from anywhere
+	
+    HasCraftBooks = false,    --This will show a button to every location so they can buy craftbook from there
+
+    -- If you want to use BCC-UserLog API's
+    -- Global toggle for using playtime restrictions
+    useBccUserlog = false
 
 }

--- a/configs/others.lua
+++ b/configs/others.lua
@@ -4,6 +4,7 @@ local others = {
     ---- OIL REFINERY - OIL LANDS ----
     {
         locationId = "refinery",
+		craftbookCategory = "refinery_craftbook",
         coords = {
             vector3(488.98, 671.69, 117.34)
         },
@@ -44,7 +45,8 @@ local others = {
                         requiredItems = {
                             { itemName = "petroleum", itemLabel = "Crude Oil", itemCount = 10, removeItem = true },
                         },
-                        playAnimation = false
+                        playAnimation = false,
+                        requiredPlaytimeMinutes = 0
                     },
                     {
                         itemName = "petrol",
@@ -57,7 +59,8 @@ local others = {
                         requiredItems = {
                             { itemName = "petroleum", itemLabel = "Crude Oil", itemCount = 10, removeItem = true },
                         },
-                        playAnimation = false
+                        playAnimation = false,
+                        requiredPlaytimeMinutes = 0
                     }
                 }
             }
@@ -106,7 +109,8 @@ local others = {
                         requiredItems = {
                             { itemName = "tobacco_leafs", itemLabel = "Tobacco Leaves", itemCount = 1, removeItem = true }
                         },
-                        playAnimation = false
+                        playAnimation = false,
+                        requiredPlaytimeMinutes = 0
                     },
                     {
                         itemName = "cigar",
@@ -119,7 +123,8 @@ local others = {
                         requiredItems = {
                             { itemName = "tobaccopipe", itemLabel = "Dried Tobacco", itemCount = 3, removeItem = true }
                         },
-                        playAnimation = false
+                        playAnimation = false,
+                        requiredPlaytimeMinutes = 0
                     },
                     {
                         itemName = "cigarette",
@@ -133,7 +138,8 @@ local others = {
                             { itemName = "tobaccopipe",  itemLabel = "Dried Tobacco", itemCount = 5, removeItem = true },
                             { itemName = "rollingpaper", itemLabel = "Rolling Paper", itemCount = 5, removeItem = true }
                         },
-                        playAnimation = false
+                        playAnimation = false,
+                        requiredPlaytimeMinutes = 0
                     },
                     {
                         itemName = "cigaret",
@@ -147,7 +153,8 @@ local others = {
                             { itemName = "cigarette", itemLabel = "Cigarette", itemCount = 10, removeItem = true },
                             { itemName = "paper",     itemLabel = "Paper",     itemCount = 1,  removeItem = true }
                         },
-                        playAnimation = false
+                        playAnimation = false,
+                        requiredPlaytimeMinutes = 0
                     }
                 }
             }

--- a/configs/weapons.lua
+++ b/configs/weapons.lua
@@ -2,7 +2,8 @@ CraftingLocations = CraftingLocations or {}
 
 local weapons = {
     {
-        locationId = "weapons",
+        locationId = "weapons"
+		craftbookCategory = "weapons_craftbook",
         coords = {
             vector3(414.96, -1275.21, 41.76)
         },
@@ -46,7 +47,8 @@ local weapons = {
                             { itemName = "nails", itemLabel = "Nails", itemCount = 1, removeItem = true },
                             { itemName = "ironhammer", itemLabel = "Iron Hammer", itemCount = 1, removeItem = false },
                         },
-                        playAnimation = false
+                        playAnimation = false,
+                        requiredPlaytimeMinutes = 0
                     },
                     {
                         itemName = "WEAPON_MELEE_LANTERN",
@@ -63,7 +65,8 @@ local weapons = {
                             { itemName = "trainoil", itemLabel = "Oil", itemCount = 1, removeItem = true },
                             { itemName = "pliers", itemLabel = "Pliers", itemCount = 1, removeItem = false }
                         },
-                        playAnimation = false
+                        playAnimation = false,
+                        requiredPlaytimeMinutes = 0
                     },
                     {
                         itemName = "WEAPON_MELEE_DAVY_LANTERN",
@@ -80,7 +83,8 @@ local weapons = {
                             { itemName = "trainoil", itemLabel = "Oil", itemCount = 1, removeItem = true },
                             { itemName = "pliers", itemLabel = "Pliers", itemCount = 1, removeItem = false }
                         },
-                        playAnimation = false
+                        playAnimation = false,
+                        requiredPlaytimeMinutes = 0
                     }
                 }
             },
@@ -109,7 +113,8 @@ local weapons = {
                             { itemName = "screwdriver", itemLabel = "Screwdriver", itemCount = 1, removeItem = false },
                             { itemName = "pliers", itemLabel = "Pliers", itemCount = 1, removeItem = false },
                         },
-                        playAnimation = false
+                        playAnimation = false,
+                        requiredPlaytimeMinutes = 0
                     },
                     {
                         itemName = "WEAPON_REVOLVER_LEMAT",
@@ -126,7 +131,8 @@ local weapons = {
                             { itemName = "screwdriver", itemLabel = "Screwdriver", itemCount = 1, removeItem = false },
                             { itemName = "pliers", itemLabel = "Pliers", itemCount = 1, removeItem = false },
                         },
-                        playAnimation = false
+                        playAnimation = false,
+                        requiredPlaytimeMinutes = 0
                     },
                     {
                         itemName = "WEAPON_REVOLVER_SCHOFIELD",
@@ -143,7 +149,8 @@ local weapons = {
                             { itemName = "screwdriver", itemLabel = "Screwdriver", itemCount = 1, removeItem = false },
                             { itemName = "pliers", itemLabel = "Pliers", itemCount = 1, removeItem = false },
                         },
-                        playAnimation = false
+                        playAnimation = false,
+                        requiredPlaytimeMinutes = 0
                     },
                     {
                         itemName = "WEAPON_REVOLVER_CATTLEMAN",
@@ -160,7 +167,8 @@ local weapons = {
                             { itemName = "screwdriver", itemLabel = "Screwdriver", itemCount = 1, removeItem = false },
                             { itemName = "pliers", itemLabel = "Pliers", itemCount = 1, removeItem = false },
                         },
-                        playAnimation = false
+                        playAnimation = false,
+                        requiredPlaytimeMinutes = 0
                     }
                 }
             }

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -35,4 +35,4 @@ dependency {
     'feather-progressbar'
 }
 
-version '1.1.0'
+version '1.2.0'

--- a/languages/en_lang.lua
+++ b/languages/en_lang.lua
@@ -73,5 +73,6 @@ Locales["en_lang"] = {
     NoJobNeeded = "N/A",
     CraftingComplete = "Crafting Completed",
     CraftingFailed = "Crafting Failed",
-    PreparingCampFire = "Setting up campfire..."
+    PreparingCampFire = "Preparing the campfire...",
+    maxCraftAmount = "Max Craftable Amount: ",
 }

--- a/languages/ro_lang.lua
+++ b/languages/ro_lang.lua
@@ -73,5 +73,6 @@ Locales["ro_lang"] = {
     NoJobNeeded = "Fara",
     CraftingComplete = "Ai terminat de craftat",
     CraftingFailed = "Nu ai putut crafta acest obiect",
-    PreparingCampFire = "Se prepara focul de tabara..."
+    PreparingCampFire = "Se prepara focul de tabara...",
+    maxCraftAmount = "Cantitatea maxima ce poate fi craftata: ",
 }

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -2,6 +2,10 @@ VORPcore = exports.vorp_core:GetCore()
 BccUtils = exports['bcc-utils'].initiate()
 Discord = BccUtils.Discord.setup(Config.WebhookLink, Config.WebhookTitle, Config.WebhookAvatar) -- Setup Discord webhook
 
+if Config.useBccUserlog then
+    UserLogAPI = exports['bcc-userlog']:getUserLogAPI()
+end
+
 -- Helper function for debugging in DevMode
 if Config.devMode then
     function devPrint(message)

--- a/version
+++ b/version
@@ -1,2 +1,2 @@
-<1.1.0>
+<1.2.0>
 See GitHub for updates!


### PR DESCRIPTION
- Added location-wide craftbooks, with per-category books still available.
- Integrated `FeatherMenu:Notify()` for client-side notifications.
- Added configurable button to allow players to get craftbooks from locations.
- Added Bcc-Userlog API integration to enforce playtime for crafting.
- `bcc-crafting:getWeaponLimit` added to check weapon crafting limits.
- some more improvements..